### PR TITLE
Various fixes for GCC 8

### DIFF
--- a/lib/differential_phase_detection_1bit_cf_impl.cc
+++ b/lib/differential_phase_detection_1bit_cf_impl.cc
@@ -150,7 +150,7 @@ namespace gr {
 		}
 
 		gr_complex nco;
-		nco = cos(-d_phase) + 1i*sin(-d_phase);
+		nco = cos(-d_phase) + 1j*sin(-d_phase);
 
 		for(int j=0; j<(d_taps.size()-1); j++)
 		{

--- a/lib/fft_estimator_cc_impl.cc
+++ b/lib/fft_estimator_cc_impl.cc
@@ -76,7 +76,7 @@ namespace gr {
 				}
 	
 				float power_s = 0;
-				int index_s;
+				int index_s = 0;
 				for(int j=0; j<d_fft_size; j++)
 				{
 					float sum;

--- a/lib/fft_estimator_cc_impl.cc
+++ b/lib/fft_estimator_cc_impl.cc
@@ -162,7 +162,7 @@ namespace gr {
 							float phase_acc = 0.0f;
 							for(int j=0; j<d_fft_size; j++)
 							{
-								coeff = cos(-phase_acc) + 1i * sin(-phase_acc);
+								coeff = cos(-phase_acc) + 1j * sin(-phase_acc);
 
 								sum += in_s[i*d_fft_size+j] * coeff;
 

--- a/lib/lrtc_mod_bc_impl.cc
+++ b/lib/lrtc_mod_bc_impl.cc
@@ -105,7 +105,8 @@ namespace gr {
         float dp = in[i]?d_dp:-d_dp;
         for(j=0; j<256; j++)
         {
-          out[i*256+j] = asm32[j].real() * cos(d_pacc) - asm32[j].imag() * sin(d_pacc) + 1j*(asm32[j].real() * sin(d_pacc) + asm32[j].imag() * cos(d_pacc));
+          out[i*256+j] = asm32[j].real() * cos(d_pacc) - asm32[j].imag() * sin(d_pacc) + 1j * (
+          			asm32[j].real() * sin(d_pacc) + asm32[j].imag() * cos(d_pacc));
 
           d_pacc = d_pacc + dp;
 

--- a/lib/oqpsk_coherent_demod_cc_impl.cc
+++ b/lib/oqpsk_coherent_demod_cc_impl.cc
@@ -182,7 +182,7 @@ namespace gr {
 		}
 		
 		gr_complex nco;
-		nco = cos(-d_phase) + 1i*sin(-d_phase);
+		nco = cos(-d_phase) + 1j*sin(-d_phase);
 
 		for(int j=0; j<(d_taps.size()-1); j++)
 		{
@@ -209,7 +209,7 @@ namespace gr {
 			//out[i_output].imag() = d_mf_out[d_samples_per_symbol/2].imag();
 
 			/* For opt_point=4, [B0, B1], [B2, B3]... */
-			out[i_output] = d_mf_out[0].imag() + 1i*d_mf_out[d_samples_per_symbol/2].real();
+			out[i_output] = d_mf_out[0].imag() + 1j*d_mf_out[d_samples_per_symbol/2].real();
 			i_output++;
 			d_symbols_since_asm++;
 

--- a/lib/program_tracking_cc_impl.cc
+++ b/lib/program_tracking_cc_impl.cc
@@ -364,7 +364,7 @@ namespace gr {
 				}
 
 				out[i] = k_real * in[i].real() - k_imag * in[i].imag()
-				  + 1i * (k_real * in[i].imag() + k_imag * in[i].real());
+				  + 1j * (k_real * in[i].imag() + k_imag * in[i].real());
 			}
 			
 


### PR DESCRIPTION
Fixes and unitialized variable and replaces 1i by 1j (when writing out complex numbers).